### PR TITLE
Add option to always open a new window

### DIFF
--- a/custom_iterm_script.applescript
+++ b/custom_iterm_script.applescript
@@ -1,15 +1,22 @@
+-- change this property to true to always use a new window
+property open_in_new_window : false
+
 on alfred_script(q)
 	tell application "iTerm"
 		if application "iTerm" is running then
-			try
-				tell the first window to create tab with default profile
-			on error
+			if open_in_new_window is true then
 				create window with default profile
-			end try
+			else
+				try
+					tell the first window to create tab with default profile
+				on error
+					create window with default profile
+				end try
+			end if
 		end if
-
+		
 		delay 0.1 -- If we do not wait, the command may fail to send
-
+		
 		tell the first window to tell current session to write text q
 		activate
 	end tell

--- a/custom_iterm_script.applescript
+++ b/custom_iterm_script.applescript
@@ -1,4 +1,4 @@
--- change this property to true to always use a new window
+-- Change this property to true to always use a new window
 property open_in_new_window : false
 
 on alfred_script(q)
@@ -14,9 +14,9 @@ on alfred_script(q)
 				end try
 			end if
 		end if
-		
+
 		delay 0.1 -- If we do not wait, the command may fail to send
-		
+
 		tell the first window to tell current session to write text q
 		activate
 	end tell


### PR DESCRIPTION
Add a property to control whether to open in a new window or attempt to open a tab in an existing window. The default remains to open a tab in an existing window; users can change `false` to `true` to force a new window. This is just a small quality-of-life improvement.