### PR TITLE
Fix iTerm2 startup issues and additional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ AppleScript for [iTerm2](https://iterm2.com/) [Alfred](https://www.alfredapp.com
 4. Select the text in the box.
 4. Paste.
 
+## Optional property settings:
+
+1. Set `open_in_new_window` to `true` to always open command in new window.
+1. Set `new_session_on_startup` to `true` to always open a new session/tab if Alfred starts the app.
+1. Set `always_activate` to `false` if you don't want to raise and switch keyboard focus to show output.
+
 ### Copy the script
 
 To copy the script to your clipboard, run the following command.

--- a/custom_iterm_script.applescript
+++ b/custom_iterm_script.applescript
@@ -1,15 +1,22 @@
+-- change this property to true to always use a new window
+property open_in_new_window : false
+
 on alfred_script(q)
 	tell application "iTerm"
 		if application "iTerm" is running then
-			try
-				tell the first window to create tab with default profile
-			on error
+			if open_in_new_window is true then
 				create window with default profile
-			end try
+			else
+				try
+					tell the first window to create tab with default profile
+				on error
+					create window with default profile
+				end try
+			end if
 		end if
-
+		
 		delay 0.1 -- If we do not wait, the command may fail to send
-
+		
 		tell the first window to tell current session to write text q
 		activate
 	end tell

--- a/custom_iterm_script.applescript
+++ b/custom_iterm_script.applescript
@@ -1,23 +1,41 @@
 -- change this property to true to always use a new window
 property open_in_new_window : false
 
+-- change this property to true to always start new session on startup
+property new_session_on_startup : false
+
+-- set this property to true to always activate and raise the window
+property always_activate : true
+
 on alfred_script(q)
+	set iterm_started to false
+	set num_windows to 0
 	tell application "iTerm"
-		if application "iTerm" is running then
-			if open_in_new_window is true then
-				create window with default profile
+		if application "iTerm" is not running then
+			activate
+			set iterm_started to true
+		end if
+		repeat with aWindow in windows
+			set num_windows to num_windows + 1
+		end repeat
+		if open_in_new_window is true or num_windows is equal to 0 then
+			create window with default profile
+		else
+			select current window
+			if iterm_started is false then
+				tell the current window to create tab with default profile
 			else
-				try
-					tell the first window to create tab with default profile
-				on error
-					create window with default profile
-				end try
+				if new_session_on_startup is true then
+					tell the current window to create tab with default profile
+				end if
 			end if
 		end if
 		
 		delay 0.1 -- If we do not wait, the command may fail to send
 		
-		tell the first window to tell current session to write text q
-		activate
+		tell the current window to tell current session to write text q
+		if always_activate is true then
+			activate
+		end if
 	end tell
 end alfred_script


### PR DESCRIPTION
Building off of sammy's patch, this commit fixes script to startup iTerm2 and operate more reliably in a variety of iTerm2 configurations and if it isn't already running.

While in the code I also added two more property options:
- always open a new session/tab if Alfred starts iTerm2
- whether to raise and switch keyboard focus to show output if iTerm2 is already running

Updated README.md to describe optional property settings.