### PR TITLE
Adds close script

### DIFF
--- a/custom_iterm_script.applescript
+++ b/custom_iterm_script.applescript
@@ -10,6 +10,28 @@ on new_tab()
 	tell application "iTerm" to tell the first window to create tab with default profile
 end new_tab
 
+on close()
+	tell application "iTerm"
+		set isBusy to true
+		repeat until isBusy is false
+			tell current session of first window
+				if (is processing) then
+					set isBusy to true
+				else
+					set isBusy to false
+				end if
+			end tell
+			delay 1
+		end repeat
+		
+		if open_in_new_window then
+			tell application "iTerm" to tell first window to close
+		else
+			tell application "iTerm" to tell current tab of first window to close
+		end if
+	end tell
+end close
+
 on call_forward()
 	tell application "iTerm" to activate
 end call_forward
@@ -53,4 +75,5 @@ on alfred_script(query)
 
 	send_text(query)
 	call_forward()
+	close()
 end alfred_script

--- a/custom_iterm_script.applescript
+++ b/custom_iterm_script.applescript
@@ -25,7 +25,7 @@ on close()
 		end repeat
 		
 		if open_in_new_window then
-			tell application "iTerm" to tell first window to close
+			tell current session of first window to close
 		else
 			tell application "iTerm" to tell current tab of first window to close
 		end if


### PR DESCRIPTION
I found that after running a number of iTerm scripts via Alfred that I had a bunch of extra tabs open. I modified the original script to add a close function to prevent this scenario. 

It has a check that waits until the active iTerm process is complete and then either closes the tab (or window if set).

The only potential hazzard here is if someone were to run a script and then open another iterm tab or window prior to that script completing, in that case it will close the tab/window that is active.