### PR TITLE
Open new window when launching iTerm

### DIFF
--- a/custom_iterm_script.applescript
+++ b/custom_iterm_script.applescript
@@ -46,6 +46,8 @@ on alfred_script(query)
 			new_window()
 		else
 			call_forward()
+			delay 0.01
+			new_window()
 		end if
 	end if
 


### PR DESCRIPTION
I encountered the same issue described in #41, #42, and #43. The script in #41 works, but this update to the current script works, as well. 

If iTerm isn't running, it activates it, then opens a new window.