### PR TITLE
Add delay before sending command from alfred

### DIFF
--- a/custom_iterm_script.applescript
+++ b/custom_iterm_script.applescript
@@ -56,9 +56,10 @@ on alfred_script(query)
 
 	-- Make sure a window exists before we continue, or the write may fail
 	repeat until has_windows()
-		delay 0.01
+		delay 0.5
 	end repeat
 
+	delay 0.5
 	send_text(query)
 	call_forward()
 end alfred_script


### PR DESCRIPTION
I had problems on my m1 pro mac, so that iterm opened without the commands typed in alfred. I cured it with such delays.